### PR TITLE
 Add ability to explicitly skip TLS verification

### DIFF
--- a/cmd/dp-deployer/main.go
+++ b/cmd/dp-deployer/main.go
@@ -15,16 +15,17 @@ import (
 )
 
 var (
-	consumerQueue    = flag.String("consumer-queue", "", "sqs consumer queue name")
-	consumerQueueURL = flag.String("consumer-queue-url", "", "sqs queue url")
-	deploymentRoot   = flag.String("deployment-root", "", "root deployment directory")
-	nomadEndpoint    = flag.String("nomad-endpoint", "http://localhost:4646", "nomad client endpoint")
-	nomadToken       = flag.String("nomad-token", "", "nomad acl token")
-	nomadCACert      = flag.String("nomad-ca-cert", "", "nomad CA cert file")
-	privateKey       = flag.String("private-key", "", "private key used to decrypt secrets")
-	producerQueue    = flag.String("producer-queue", "", "sqs producer queue name")
-	region           = flag.String("aws-default-region", "", "sqs queue region")
-	verificationKey  = flag.String("verification-key", "", "public key for verifying queue messages")
+	consumerQueue      = flag.String("consumer-queue", "", "sqs consumer queue name")
+	consumerQueueURL   = flag.String("consumer-queue-url", "", "sqs queue url")
+	deploymentRoot     = flag.String("deployment-root", "", "root deployment directory")
+	nomadEndpoint      = flag.String("nomad-endpoint", "http://localhost:4646", "nomad client endpoint")
+	nomadTlsSkipVerify = flag.Bool("nomad-tls-skip-verify", false, "skip tls verification of nomad cert")
+	nomadToken         = flag.String("nomad-token", "", "nomad acl token")
+	nomadCACert        = flag.String("nomad-ca-cert", "", "nomad CA cert file")
+	privateKey         = flag.String("private-key", "", "private key used to decrypt secrets")
+	producerQueue      = flag.String("producer-queue", "", "sqs producer queue name")
+	region             = flag.String("aws-default-region", "", "sqs queue region")
+	verificationKey    = flag.String("verification-key", "", "public key for verifying queue messages")
 )
 
 var wg sync.WaitGroup
@@ -71,11 +72,12 @@ func main() {
 
 func initHandlers() (map[string]engine.HandlerFunc, error) {
 	dc := &deployment.Config{
-		DeploymentRoot: *deploymentRoot,
-		NomadEndpoint:  *nomadEndpoint,
-		NomadToken:     *nomadToken,
-		NomadCACert:    *nomadCACert,
-		Region:         *region,
+		DeploymentRoot:     *deploymentRoot,
+		NomadEndpoint:      *nomadEndpoint,
+		NomadTlsSkipVerify: *nomadTlsSkipVerify,
+		NomadToken:         *nomadToken,
+		NomadCACert:        *nomadCACert,
+		Region:             *region,
 	}
 	d, err := deployment.New(dc)
 	if err != nil {

--- a/dp-deployer.nomad
+++ b/dp-deployer.nomad
@@ -41,6 +41,10 @@ job "dp-deployer" {
       resources {
         cpu    = "{{MANAGEMENT_RESOURCE_CPU}}"
         memory = "{{MANAGEMENT_RESOURCE_MEM}}"
+
+        network {
+          port "http" {}
+        }
       }
 
       template {

--- a/handler/deployment/deployment_test.go
+++ b/handler/deployment/deployment_test.go
@@ -34,15 +34,24 @@ func TestNew(t *testing.T) {
 	defer os.Unsetenv("AWS_CREDENTIAL_FILE")
 
 	Convey("an error is returned with invalid configuration", t, func() {
-		d, err := New(&Config{"foo", "bar", "baz", "", "qux", nil})
+		d, err := New(&Config{"foo", "bar", "baz", "", false, "qux", nil})
 		So(d, ShouldBeNil)
 		So(err, ShouldNotBeNil)
 		So(err.Error(), ShouldStartWith, "No valid AWS authentication found")
 	})
 
 	withEnv(func() {
+		Convey("an error is returned with invalid tls configuration", t, func() {
+			d, err := New(&Config{"foo", "https://", "baz", "", false, "qux", nil})
+			So(d, ShouldBeNil)
+			So(err, ShouldNotBeNil)
+			So(err.Error(), ShouldStartWith, "invalid configuration with https")
+		})
+	})
+
+	withEnv(func() {
 		Convey("default timeout configuration is used when timeout is not configured", t, func() {
-			d, err := New(&Config{"foo", "bar", "baz", "", "qux", nil})
+			d, err := New(&Config{"foo", "bar", "baz", "", false, "qux", nil})
 			So(err, ShouldBeNil)
 			So(d, ShouldNotBeNil)
 			So(d.timeout.Allocation, ShouldEqual, DefaultAllocationTimeout)
@@ -52,7 +61,7 @@ func TestNew(t *testing.T) {
 
 	withEnv(func() {
 		Convey("default timeout configuration is used when timeout is unreasonable", t, func() {
-			d, err := New(&Config{"foo", "bar", "baz", "", "qux", &TimeoutConfig{0, 0}})
+			d, err := New(&Config{"foo", "bar", "baz", "", false, "qux", &TimeoutConfig{0, 0}})
 			So(err, ShouldBeNil)
 			So(d, ShouldNotBeNil)
 			So(d.timeout.Allocation, ShouldEqual, DefaultAllocationTimeout)


### PR DESCRIPTION
As the deployer is now running inside a docker container it will not be
able to access Nomad on `localhost`.  Therefore, only disabling TLS
verification on connections that include localhost is not enough.  This
change adds a configuration to enable the user to explicitly skip the
TLS verification if desired.

Also add the network resource to nomad plan to get access to host IP.

Depends on https://github.com/ONSdigital/dp-ci/pull/672