### PR TITLE
Feature/system job deployment

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ build
 /dp-deployer
 *.tar.gz
 dp-deployer.sh
+.idea/

--- a/Makefile
+++ b/Makefile
@@ -17,7 +17,7 @@ all: audit test build
 
 .PHONY: audit
 audit:
-	nancy go.sum
+	go list -m all | nancy sleuth
 
 .PHONY: build
 build:

--- a/handler/deployment/deployment.go
+++ b/handler/deployment/deployment.go
@@ -272,15 +272,14 @@ func (d *Deployment) systemDeploymentSuccess(ctx context.Context, correlationID,
 				return &AbortedError{EvaluationID: evaluationID, CorrelationID: correlationID}
 			}
 
-			updateComplete := true
+			updatedAllocations := 0
 			for _, allocation := range allocations {
-				if allocation.JobVersion != jobVersion || allocation.ClientStatus != structs.AllocClientStatusRunning {
-					updateComplete = false
-					break
+				if allocation.JobVersion == jobVersion && allocation.ClientStatus == structs.AllocClientStatusRunning {
+					updatedAllocations += 1
 				}
 			}
 
-			if updateComplete {
+			if len(allocations) == updatedAllocations {
 				log.Event(ctx, "deployment success", log.INFO, minLogData)
 				return nil
 			}

--- a/handler/deployment/deployment.go
+++ b/handler/deployment/deployment.go
@@ -283,9 +283,8 @@ func (d *Deployment) systemDeploymentSuccess(ctx context.Context, correlationID,
 			if updateComplete {
 				log.Event(ctx, "deployment success", log.INFO, minLogData)
 				return nil
-			} else {
-				log.Event(ctx, "deployment incomplete - will re-test", log.WARN, minLogData)
 			}
+			log.Event(ctx, "deployment incomplete - will re-test", log.WARN, minLogData)
 		}
 	}
 }

--- a/handler/deployment/deployment.go
+++ b/handler/deployment/deployment.go
@@ -25,7 +25,7 @@ import (
 )
 
 const (
-	infoURL		   	= "%s/v1/job/%s"
+	infoURL	        = "%s/v1/job/%s"
 	deploymentURL  	= "%s/v1/job/%s/deployments"
 	allocationsURL 	= "%s/v1/job/%s/allocations"
 	planURL        	= "%s/v1/job/%s/plan"

--- a/handler/deployment/deployment.go
+++ b/handler/deployment/deployment.go
@@ -165,8 +165,14 @@ func (d *Deployment) runNew(ctx context.Context, job api.Job) error {
 	if err := d.post(fmt.Sprintf(runURL, d.endpoint), job.Payload, &res); err != nil {
 		return err
 	}
-	if err := d.deploymentSuccess(ctx, *job.Name, res.EvalID, *job.Name, res.JobModifyIndex); err != nil {
-		return err
+	if *job.Type == api.JobTypeSystem {
+		if err := d.systemDeploymentSuccess(ctx, *job.Name, res.EvalID, *job.Name, *job.Version); err != nil {
+			return err
+		}
+	} else {
+		if err := d.serviceDeploymentSuccess(ctx, *job.Name, res.EvalID, *job.Name, res.JobModifyIndex); err != nil {
+			return err
+		}
 	}
 	return nil
 }

--- a/handler/deployment/deployment_test.go
+++ b/handler/deployment/deployment_test.go
@@ -118,7 +118,7 @@ func TestRun(t *testing.T) {
 			})
 
 			Convey("job info api errors handled correctly", func() {
-				serviceName :="test"
+				serviceName := "test"
 				httpmock.RegisterResponder("POST", fmt.Sprintf(runURL, nomadURL), httpmock.NewStringResponder(500, "server error"))
 				httpmock.RegisterResponder("GET", fmt.Sprintf(infoURL, nomadURL, serviceName), httpmock.NewStringResponder(500, "server error"))
 				dep := &Deployment{endpoint: nomadURL, nomadClient: nomadClient}
@@ -129,7 +129,7 @@ func TestRun(t *testing.T) {
 			})
 
 			Convey("deployment api errors handled correctly", func() {
-				serviceName :="test"
+				serviceName := "test"
 				httpmock.RegisterResponder("POST", fmt.Sprintf(runURL, nomadURL), httpmock.NewStringResponder(200, jobSuccess))
 				httpmock.RegisterResponder("GET", fmt.Sprintf(infoURL, nomadURL, serviceName), httpmock.NewStringResponder(200, serviceJobInfoSuccess))
 				httpmock.RegisterResponder("GET", fmt.Sprintf(deploymentURL, nomadURL, serviceName), httpmock.NewStringResponder(500, "server error"))
@@ -141,7 +141,7 @@ func TestRun(t *testing.T) {
 			})
 
 			Convey("deployment api failures handled correctly", func() {
-				serviceName :="test"
+				serviceName := "test"
 				httpmock.RegisterResponder("POST", fmt.Sprintf(runURL, nomadURL), httpmock.NewStringResponder(200, jobSuccess))
 				httpmock.RegisterResponder("GET", fmt.Sprintf(infoURL, nomadURL, serviceName), httpmock.NewStringResponder(200, serviceJobInfoSuccess))
 				httpmock.RegisterResponder("GET", fmt.Sprintf(deploymentURL, nomadURL, serviceName), httpmock.NewStringResponder(200, deploymentError))
@@ -153,7 +153,7 @@ func TestRun(t *testing.T) {
 			})
 
 			Convey("service deployment timeouts handled correctly", func() {
-				serviceName :="test"
+				serviceName := "test"
 				httpmock.RegisterResponder("POST", fmt.Sprintf(runURL, nomadURL), httpmock.NewStringResponder(200, jobSuccess))
 				httpmock.RegisterResponder("GET", fmt.Sprintf(infoURL, nomadURL, serviceName), httpmock.NewStringResponder(200, serviceJobInfoSuccess))
 				httpmock.RegisterResponder("GET", fmt.Sprintf(deploymentURL, nomadURL, serviceName), httpmock.NewStringResponder(200, deploymentRunning))
@@ -165,7 +165,7 @@ func TestRun(t *testing.T) {
 			})
 
 			Convey("service deployment cancellation handled correctly", func() {
-				serviceName :="test"
+				serviceName := "test"
 				httpmock.RegisterResponder("POST", fmt.Sprintf(runURL, nomadURL), httpmock.NewStringResponder(200, jobSuccess))
 				httpmock.RegisterResponder("GET", fmt.Sprintf(infoURL, nomadURL, serviceName), httpmock.NewStringResponder(200, serviceJobInfoSuccess))
 				httpmock.RegisterResponder("GET", fmt.Sprintf(deploymentURL, nomadURL, serviceName), httpmock.NewStringResponder(200, deploymentRunning))
@@ -177,7 +177,7 @@ func TestRun(t *testing.T) {
 			})
 
 			Convey("successful service deployments handled correctly", func() {
-				serviceName :="test"
+				serviceName := "test"
 				httpmock.RegisterResponder("POST", fmt.Sprintf(runURL, nomadURL), httpmock.NewStringResponder(200, jobSuccess))
 				httpmock.RegisterResponder("GET", fmt.Sprintf(infoURL, nomadURL, serviceName), httpmock.NewStringResponder(200, serviceJobInfoSuccess))
 				httpmock.RegisterResponder("GET", fmt.Sprintf(deploymentURL, nomadURL, serviceName), httpmock.NewStringResponder(200, deploymentSuccess))
@@ -188,7 +188,7 @@ func TestRun(t *testing.T) {
 			})
 
 			Convey("allocations api errors handled correctly", func() {
-				serviceName :="test"
+				serviceName := "test"
 				httpmock.RegisterResponder("POST", fmt.Sprintf(runURL, nomadURL), httpmock.NewStringResponder(200, jobSuccess))
 				httpmock.RegisterResponder("GET", fmt.Sprintf(infoURL, nomadURL, serviceName), httpmock.NewStringResponder(200, systemJobInfoSuccess))
 				httpmock.RegisterResponder("GET", fmt.Sprintf(allocationsURL, nomadURL, serviceName), httpmock.NewStringResponder(500, "server error"))
@@ -200,7 +200,7 @@ func TestRun(t *testing.T) {
 			})
 
 			Convey("empty allocations api response handled correctly", func() {
-				serviceName :="test"
+				serviceName := "test"
 				httpmock.RegisterResponder("POST", fmt.Sprintf(runURL, nomadURL), httpmock.NewStringResponder(200, jobSuccess))
 				httpmock.RegisterResponder("GET", fmt.Sprintf(infoURL, nomadURL, serviceName), httpmock.NewStringResponder(200, systemJobInfoSuccess))
 				httpmock.RegisterResponder("GET", fmt.Sprintf(allocationsURL, nomadURL, serviceName), httpmock.NewStringResponder(200, emptyAllocations))
@@ -212,7 +212,7 @@ func TestRun(t *testing.T) {
 			})
 
 			Convey("system deployment timeouts handled correctly", func() {
-				serviceName :="test"
+				serviceName := "test"
 				httpmock.RegisterResponder("POST", fmt.Sprintf(runURL, nomadURL), httpmock.NewStringResponder(200, jobSuccess))
 				httpmock.RegisterResponder("GET", fmt.Sprintf(infoURL, nomadURL, serviceName), httpmock.NewStringResponder(200, systemJobInfoSuccess))
 				httpmock.RegisterResponder("GET", fmt.Sprintf(allocationsURL, nomadURL, serviceName), httpmock.NewStringResponder(200, allocationsPending))
@@ -224,7 +224,7 @@ func TestRun(t *testing.T) {
 			})
 
 			Convey("system deployment cancellation handled correctly", func() {
-				serviceName :="test"
+				serviceName := "test"
 				httpmock.RegisterResponder("POST", fmt.Sprintf(runURL, nomadURL), httpmock.NewStringResponder(200, jobSuccess))
 				httpmock.RegisterResponder("GET", fmt.Sprintf(infoURL, nomadURL, serviceName), httpmock.NewStringResponder(200, systemJobInfoSuccess))
 				httpmock.RegisterResponder("GET", fmt.Sprintf(allocationsURL, nomadURL, serviceName), httpmock.NewStringResponder(200, allocationsPending))
@@ -236,7 +236,7 @@ func TestRun(t *testing.T) {
 			})
 
 			Convey("system deployment failed allocation handled correctly", func() {
-				serviceName :="test"
+				serviceName := "test"
 				httpmock.RegisterResponder("POST", fmt.Sprintf(runURL, nomadURL), httpmock.NewStringResponder(200, jobSuccess))
 				httpmock.RegisterResponder("GET", fmt.Sprintf(infoURL, nomadURL, serviceName), httpmock.NewStringResponder(200, systemJobInfoSuccess))
 				httpmock.RegisterResponder("GET", fmt.Sprintf(allocationsURL, nomadURL, serviceName), httpmock.NewStringResponder(200, allocationsError))
@@ -248,7 +248,7 @@ func TestRun(t *testing.T) {
 			})
 
 			Convey("system deployment old version persists handled correctly", func() {
-				serviceName :="test"
+				serviceName := "test"
 				httpmock.RegisterResponder("POST", fmt.Sprintf(runURL, nomadURL), httpmock.NewStringResponder(200, jobSuccess))
 				httpmock.RegisterResponder("GET", fmt.Sprintf(infoURL, nomadURL, serviceName), httpmock.NewStringResponder(200, systemJobInfoSuccess))
 				httpmock.RegisterResponder("GET", fmt.Sprintf(allocationsURL, nomadURL, serviceName), httpmock.NewStringResponder(200, allocationsOldVersion))
@@ -260,7 +260,7 @@ func TestRun(t *testing.T) {
 			})
 
 			Convey("successful system deployments handled correctly", func() {
-				serviceName :="test"
+				serviceName := "test"
 				httpmock.RegisterResponder("POST", fmt.Sprintf(runURL, nomadURL), httpmock.NewStringResponder(200, jobSuccess))
 				httpmock.RegisterResponder("GET", fmt.Sprintf(infoURL, nomadURL, serviceName), httpmock.NewStringResponder(200, systemJobInfoSuccess))
 				httpmock.RegisterResponder("GET", fmt.Sprintf(allocationsURL, nomadURL, serviceName), httpmock.NewStringResponder(200, allocationsSuccess))

--- a/handler/deployment/deployment_test.go
+++ b/handler/deployment/deployment_test.go
@@ -128,7 +128,7 @@ func TestRun(t *testing.T) {
 				cancel()
 			})
 
-			Convey("deployment api errors handled correctly", func() {
+			Convey("service deployment api errors handled correctly", func() {
 				serviceName := "test"
 				httpmock.RegisterResponder("POST", fmt.Sprintf(runURL, nomadURL), httpmock.NewStringResponder(200, jobSuccess))
 				httpmock.RegisterResponder("GET", fmt.Sprintf(infoURL, nomadURL, serviceName), httpmock.NewStringResponder(200, serviceJobInfoSuccess))
@@ -140,7 +140,7 @@ func TestRun(t *testing.T) {
 				cancel()
 			})
 
-			Convey("deployment api failures handled correctly", func() {
+			Convey("service deployment api failures handled correctly", func() {
 				serviceName := "test"
 				httpmock.RegisterResponder("POST", fmt.Sprintf(runURL, nomadURL), httpmock.NewStringResponder(200, jobSuccess))
 				httpmock.RegisterResponder("GET", fmt.Sprintf(infoURL, nomadURL, serviceName), httpmock.NewStringResponder(200, serviceJobInfoSuccess))
@@ -187,7 +187,7 @@ func TestRun(t *testing.T) {
 				cancel()
 			})
 
-			Convey("allocations api errors handled correctly", func() {
+			Convey("system allocations api errors handled correctly", func() {
 				serviceName := "test"
 				httpmock.RegisterResponder("POST", fmt.Sprintf(runURL, nomadURL), httpmock.NewStringResponder(200, jobSuccess))
 				httpmock.RegisterResponder("GET", fmt.Sprintf(infoURL, nomadURL, serviceName), httpmock.NewStringResponder(200, systemJobInfoSuccess))
@@ -199,7 +199,7 @@ func TestRun(t *testing.T) {
 				cancel()
 			})
 
-			Convey("empty allocations api response handled correctly", func() {
+			Convey("empty system allocations api response handled correctly", func() {
 				serviceName := "test"
 				httpmock.RegisterResponder("POST", fmt.Sprintf(runURL, nomadURL), httpmock.NewStringResponder(200, jobSuccess))
 				httpmock.RegisterResponder("GET", fmt.Sprintf(infoURL, nomadURL, serviceName), httpmock.NewStringResponder(200, systemJobInfoSuccess))
@@ -292,7 +292,7 @@ func TestRunNew(t *testing.T) {
 				cancel()
 			})
 
-			Convey("deployment api errors handled correctly", func() {
+			Convey("service deployment api errors handled correctly", func() {
 				jobType := "service"
 				httpmock.RegisterResponder("POST", fmt.Sprintf(runURL, nomadURL), httpmock.NewStringResponder(200, jobSuccess))
 				httpmock.RegisterResponder("GET", fmt.Sprintf(deploymentURL, nomadURL, jobName), httpmock.NewStringResponder(500, "server error"))
@@ -303,7 +303,7 @@ func TestRunNew(t *testing.T) {
 				cancel()
 			})
 
-			Convey("deployment api failures handled correctly", func() {
+			Convey("service deployment api failures handled correctly", func() {
 				jobType := "service"
 				httpmock.RegisterResponder("POST", fmt.Sprintf(runURL, nomadURL), httpmock.NewStringResponder(200, jobSuccess))
 				httpmock.RegisterResponder("GET", fmt.Sprintf(deploymentURL, nomadURL, jobName), httpmock.NewStringResponder(200, deploymentError))
@@ -346,7 +346,7 @@ func TestRunNew(t *testing.T) {
 				cancel()
 			})
 
-			Convey("allocations api errors handled correctly", func() {
+			Convey("system allocations api errors handled correctly", func() {
 				jobType := "system"
 				httpmock.RegisterResponder("POST", fmt.Sprintf(runURL, nomadURL), httpmock.NewStringResponder(200, jobSuccess))
 				httpmock.RegisterResponder("GET", fmt.Sprintf(allocationsURL, nomadURL, jobName), httpmock.NewStringResponder(500, "server error"))
@@ -357,7 +357,7 @@ func TestRunNew(t *testing.T) {
 				cancel()
 			})
 
-			Convey("empty allocations api response handled correctly", func() {
+			Convey("empty system allocations api response handled correctly", func() {
 				jobType := "system"
 				httpmock.RegisterResponder("POST", fmt.Sprintf(runURL, nomadURL), httpmock.NewStringResponder(200, jobSuccess))
 				httpmock.RegisterResponder("GET", fmt.Sprintf(allocationsURL, nomadURL, jobName), httpmock.NewStringResponder(200, emptyAllocations))


### PR DESCRIPTION
### What
Added support for the deployment of system type jobs.
System type jobs do not currently have 'deployments' in Nomad, causing the deployer to time out even on successful deployments.
Solution implemented is to instead poll for a list of the jobs allocations, checking their version against the jobs current version and their status.
A deployment is being considered complete once all allocations have a status of 'running' and the version matches the jobs version.
(This has been added in to the old and new 'run' functions.) 

### How to review
Ensure all non-system type jobs are unaffected by the changes and continue to be deployed correctly.
Check logic in system allocation checks will correctly flag when all allocations are updated.

### Who can review
Anyone apart from me