### PR TITLE
updated kubernetes version from 1.22.1 to 1.22.2

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -30,7 +30,7 @@ replace (
 	k8s.io/kube-scheduler => k8s.io/kube-scheduler v0.22.1
 	k8s.io/kubectl => k8s.io/kubectl v0.22.1
 	k8s.io/kubelet => k8s.io/kubelet v0.22.1
-	k8s.io/kubernetes => k8s.io/kubernetes v1.22.1
+	k8s.io/kubernetes => k8s.io/kubernetes v1.22.2
 	k8s.io/legacy-cloud-providers => k8s.io/legacy-cloud-providers v0.22.1
 	k8s.io/metrics => k8s.io/metrics v0.22.1
 	k8s.io/mount-utils => k8s.io/mount-utils v0.22.1
@@ -62,4 +62,5 @@ require (
 	github.com/smartystreets/goconvey v1.6.4
 	github.com/vaughan0/go-ini v0.0.0-20130923145212-a98ad7ee00ec // indirect
 	golang.org/x/crypto v0.0.0-20210817164053-32db794688a5
+	k8s.io/kubernetes v1.22.2 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -809,6 +809,7 @@ github.com/opencontainers/runc v0.1.1/go.mod h1:qT5XzbpPznkRYVz/mWwUaVBUv2rmF59P
 github.com/opencontainers/runc v1.0.0-rc93/go.mod h1:3NOsor4w32B2tC0Zbl8Knk4Wg84SM2ImC1fxBuqJ/H0=
 github.com/opencontainers/runc v1.0.0-rc95/go.mod h1:z+bZxa/+Tz/FmYVWkhUajJdzFeOqjc5vrqskhVyHGUM=
 github.com/opencontainers/runc v1.0.1/go.mod h1:aTaHFFwQXuA71CiyxOdFFIorAoemI04suvGRQFzWTD0=
+github.com/opencontainers/runc v1.0.2/go.mod h1:aTaHFFwQXuA71CiyxOdFFIorAoemI04suvGRQFzWTD0=
 github.com/opencontainers/runtime-spec v0.1.2-0.20190507144316-5b71a03e2700/go.mod h1:jwyrGlmzljRJv/Fgzds9SsS/C5hL+LL3ko9hs6T5lQ0=
 github.com/opencontainers/runtime-spec v1.0.2/go.mod h1:jwyrGlmzljRJv/Fgzds9SsS/C5hL+LL3ko9hs6T5lQ0=
 github.com/opencontainers/runtime-spec v1.0.3-0.20200929063507-e6143ca7d51d/go.mod h1:jwyrGlmzljRJv/Fgzds9SsS/C5hL+LL3ko9hs6T5lQ0=
@@ -1538,6 +1539,8 @@ k8s.io/kube-scheduler v0.22.1/go.mod h1:32YH9ef2m03E5LfD/H8TMTSppWq3Hav8LON9e+NG
 k8s.io/kubectl v0.22.1/go.mod h1:mjAOgEbMNMtZWxnfM6jd+nPjPsaoLqO5xanc78WcSbw=
 k8s.io/kubelet v0.22.1/go.mod h1:rZuP1msr5NH7IGApW60DYFR3Cs3On4ftWLMJRfg+iU4=
 k8s.io/kubernetes v1.22.1/go.mod h1:IGQZrV02n2IBp52+/YwLVMurCEQPKXJ/k8hU3mqEOuA=
+k8s.io/kubernetes v1.22.2 h1:EkPl3JQjkm9UA7dteLJJQOEwTsJbVINEJtaHAzm/OvE=
+k8s.io/kubernetes v1.22.2/go.mod h1:Snea7fgIObGgHmLbUJ3OgjGEr5bjj16iEdp5oHS6eS8=
 k8s.io/legacy-cloud-providers v0.22.1/go.mod h1:5ejdiQhOxTigKFrFcMvulMCyxxffmkZpk/WMgnknkwI=
 k8s.io/metrics v0.22.1/go.mod h1:i/ZNap89UkV1gLa26dn7fhKAdheJaKy+moOqJbiif7E=
 k8s.io/mount-utils v0.22.1/go.mod h1:gUi5ht+05KHYc/vJ9q9wbvG3MCYBeOsB5FdTyM60Pzo=


### PR DESCRIPTION
upated kubernetes version from 1.22.1 to 1.22.2 to fix [CVE-2021-25741] security issue. Please check dp-deployer in concourse to look for this error.
Ref: https://ossindex.sonatype.org/vulnerability/2ae7c596-34f7-4bbe-84e2-f61b36537a39?component-type=golang&component-name=k8s.io%2Fkubernetes&utm_source=nancy-client&utm_medium=integration&utm_content=1.0.17

How to review:
run make audit and it should show 0 vulnerability

Anyone can review this PR